### PR TITLE
Update to 0.7 - don't drop 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,14 @@ os:
 
 julia:
   - 0.6
+  - 0.7
+  - 1.0
   - nightly
+
+matrix:
+  allow_failures:
+    - julia: 1.0
+    - julia: nightly
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,17 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 matrix:
   allow_failures:
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
@@ -32,7 +38,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.init(); Pkg.clone(pwd(), \"LinearOperators\");"
+  - C:\projects\julia\bin\julia -e "versioninfo(); VERSION < v\"0.7.0-beta2.0\" && Pkg.init(); Pkg.clone(pwd(), \"LinearOperators\");"
 
 test_script:
   - C:\projects\julia\bin\julia -e "Pkg.test(\"LinearOperators\")"


### PR DESCRIPTION
This drops 0.6.

Maybe we could have 0.4.x for limited 0.6 support, and the next release (and current master) are 0.7 only.

Also closes #55.