### PR TITLE
Fix opEye bug

### DIFF
--- a/src/LinearOperators.jl
+++ b/src/LinearOperators.jl
@@ -478,7 +478,7 @@ check_positive_definite(M :: AbstractMatrix) = check_positive_definite(LinearOpe
 Identity operator of order `n` and of data type `T` (defaults to `Float64`).
 """
 function opEye(T :: DataType, n :: Int)
-  prod = @closure v -> v
+  prod = @closure v -> copy(v)
   F = typeof(prod)
   LinearOperator{T,F,F,F}(n, n, true, true, prod, prod, prod)
 end

--- a/test/test_linop.jl
+++ b/test/test_linop.jl
@@ -143,6 +143,10 @@ function test_linop()
       @test(abs(norm(opI' * v - v)) <= ϵ * norm(v));
       @test(norm(Matrix(opI) - Matrix(1.0I, nrow, nrow)) <= ϵ * norm(Matrix(1.0I, nrow, nrow)));
 
+      w = opI * v
+      w[1] = -1.0
+      @test v[1] != w[1]
+
       opI = opEye(nrow, ncol)
       v = rand(ncol) + rand(ncol) * im
       v0 = [v ; zeros(nrow - ncol)]


### PR DESCRIPTION
`Krylov` breaks because of [this](https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/src/symmlq.jl#L47).