### PR TITLE
opEye operator

### DIFF
--- a/src/LinearOperators.jl
+++ b/src/LinearOperators.jl
@@ -121,7 +121,6 @@ function show(io :: IO, op :: AbstractLinearOperator)
   print(io, s)
 end
 
-
 # Constructors.
 """
     LinearOperator(M; symmetric=false, hermitian=false)
@@ -469,6 +468,29 @@ end
 check_positive_definite(M :: AbstractMatrix) = check_positive_definite(LinearOperator(M))
 
 # Special linear operators.
+
+"""`opEye()`
+
+Identity operator.
+```
+opI = opEye()
+v = rand(5)
+@assert opI * v === v
+```
+"""
+struct opEye <: AbstractLinearOperator{Any,Nothing,Nothing,Nothing} end
+
+*(::opEye, x :: AbstractArray{T,1} where T) = x
+*(x :: AbstractArray{T,1} where T, ::opEye) = x
+*(::opEye, A :: AbstractArray{T,2} where T) = A
+*(A :: AbstractArray{T,2} where T, ::opEye) = A
+*(::opEye, T :: AbstractLinearOperator) = T
+*(T :: AbstractLinearOperator, ::opEye) = T
+*(::opEye, T::opEye) = T
+
+function show(io :: IO, op :: opEye)
+  println(io, "Identity operator")
+end
 
 """
     opEye(T, n)

--- a/test/test_linop.jl
+++ b/test/test_linop.jl
@@ -163,6 +163,31 @@ function test_linop()
       @test(norm(Matrix(opI) - Matrix(1.0I, ncol, nrow)) <= ϵ * norm(Matrix(1.0I, ncol, nrow)))
     end
 
+    @testset "Identity (non-convertible to matrix)" begin
+      op = opEye()
+
+      v = rand(5)
+      w = op * v
+      @test w === v
+      w = v * op
+
+      @test w === v
+      A2 = op * A1
+      @test A2 === A1
+      A2 = A1 * op
+      @test A2 === A1
+
+      T1 = LinearOperator(A1)
+      T2 = op * T1
+      @test T2 === T1
+      T2 = T1 * op
+      @test T2 === T1
+
+      op2 = opEye()
+      @test op === op2
+      @test op === op * op2 === op2 * op
+    end
+
     @testset "Ones" begin
       E = opOnes(nrow, ncol);
       v = rand(nrow) + rand(nrow) * im;
@@ -361,6 +386,7 @@ function test_linop()
     @test_throws LinearOperatorException opCholesky(A, check=true)  # Not Hermitian / positive definite
     @test_throws LinearOperatorException opCholesky(-A'*A, check=true)  # Not positive definite
   end
+
 end
 
 test_linop()


### PR DESCRIPTION
Following #66, perhaps we should consider a Bypass operator? This simply returns the Vector/Matrix/Operator. It doesn't handle any matrix information, but if you need a unsafe_opEye, then maybe Bypass could be used instead.