### PR TITLE
Add transpose and adjoint of real preallocated operator

### DIFF
--- a/src/LinearOperators.jl
+++ b/src/LinearOperators.jl
@@ -263,6 +263,13 @@ function transpose(op :: AbstractLinearOperator{T,F1,F2,F3}) where {T,F1,F2,F3}
   if op.symmetric
     return op
   end
+  if isreal(op)
+    if typeof(op) <: PreallocatedLinearOperator
+      return PreallocatedLinearOperator{T,F2,F1,F1}(op.ncol, op.nrow, op.symmetric, op.hermitian, op.tprod, op.prod, op.prod)
+    else
+      return LinearOperator{T,F2,F1,F1}(op.ncol, op.nrow, op.symmetric, op.hermitian, op.tprod, op.prod, op.prod)
+    end
+  end
   if op.tprod !== nothing
     ctprod = @closure v -> conj.(op.prod(conj.(v)))
     F4 = typeof(ctprod)
@@ -289,6 +296,13 @@ end
 function adjoint(op :: AbstractLinearOperator{T,F1,F2,F3}) where {T,F1,F2,F3}
   if op.hermitian
     return op
+  end
+  if isreal(op)
+    if typeof(op) <: PreallocatedLinearOperator
+      return PreallocatedLinearOperator{T,F2,F1,F1}(op.ncol, op.nrow, op.symmetric, op.hermitian, op.tprod, op.prod, op.prod)
+    else
+      return LinearOperator{T,F2,F1,F1}(op.ncol, op.nrow, op.symmetric, op.hermitian, op.tprod, op.prod, op.prod)
+    end
   end
   if op.ctprod !== nothing
     tprod = @closure u -> conj.(op.prod(conj.(u)))

--- a/test/test_linop.jl
+++ b/test/test_linop.jl
@@ -456,6 +456,16 @@ function test_linop()
     mul!(y, op, x)
     @test y == [2.0; 1.0]
   end
+
+  # Issue #92
+  @testset "Transpose and adjoint of real preallocated operator" begin
+    A = [1.0 1.0; 1.0 0.0]
+    op = PreallocatedLinearOperator(A)
+    transpose_op = transpose(op)
+    @test typeof(transpose_op) <: PreallocatedLinearOperator
+    adjoint_op = adjoint(op)
+    @test typeof(adjoint_op) <: PreallocatedLinearOperator
+  end
 end
 
 test_linop()


### PR DESCRIPTION
close #92 
Transpose or adjoint of `PreallocatedLinearOperator` returned a `LinearOperator`.
It why, we had so many allocation in `Krylov.jl` without `A.tprod`. 
I update it for `Real` operators but for `Complex` we need to update the structure of `PreallocatedLinearOperator` in the future to have access to preallocated vectors.