### PR TITLE
Removes {h,v,hv}cat between arbitrary number of operators and matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ julia:
   - 1.0
   - 1.1
   - 1.2
+  - 1.3
   - nightly
 
 matrix:
   allow_failures:
+    - julia: 1.3
     - julia: nightly
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:
@@ -10,6 +12,7 @@ platform:
 
 matrix:
   allow_failures:
+  - julia_version: 1.3
   - julia_version: nightly
 
 branches:

--- a/src/LinearOperators.jl
+++ b/src/LinearOperators.jl
@@ -558,7 +558,7 @@ function hcat(A :: AbstractLinearOperator, B :: AbstractLinearOperator)
   LinearOperator{S}(nrow, ncol, false, false, prod, tprod, ctprod)
 end
 
-function hcat(ops :: OperatorOrMatrix...)
+function hcat(ops :: AbstractLinearOperator...)
   op = ops[1]
   for i = 2:length(ops)
     op = [op ops[i]]
@@ -585,7 +585,7 @@ function vcat(A :: AbstractLinearOperator, B :: AbstractLinearOperator)
   return LinearOperator{S}(nrow, ncol, false, false, prod, tprod, ctprod)
 end
 
-function vcat(ops :: OperatorOrMatrix...)
+function vcat(ops :: AbstractLinearOperator...)
   op = ops[1]
   for i = 2:length(ops)
     op = [op; ops[i]]
@@ -594,9 +594,9 @@ function vcat(ops :: OperatorOrMatrix...)
 end
 
 # Removed by https://github.com/JuliaLang/julia/pull/24017
-function hvcat(rows :: Tuple{Vararg{Int}}, ops :: OperatorOrMatrix...)
+function hvcat(rows :: Tuple{Vararg{Int}}, ops :: AbstractLinearOperator...)
   nbr = length(rows)
-  rs = Array{OperatorOrMatrix,1}(undef, nbr)
+  rs = Array{AbstractLinearOperator,1}(undef, nbr)
   a = 1
   for i = 1:nbr
     rs[i] = hcat(ops[a:a-1+rows[i]]...)

--- a/test/test_cat.jl
+++ b/test/test_cat.jl
@@ -34,7 +34,7 @@ function test_cat()
     @test(norm(Do2 * rhs - D * rhs) <= rtol * norm(D * rhs))
 
     @test_throws LinearOperatorException [LinearOperator(ones(5,5)) ; opEye(3)]
-    K = [Matrix(1.0I, 2, 2) opZeros(2,3) ; opZeros(3,2) opEye(3)]
+    K = [opEye(2) opZeros(2,3) ; opZeros(3,2) opEye(3)]
     v = simple_vector(Float64, 5)
     @test all(v .== K * v)
 


### PR DESCRIPTION
hcat and vcat are still defined between one operator and one matrix.
Also updates travis and appveyor to run on Julia 1.3.

Closes #100