### PR TITLE
Allows symmetric and hermitian options for all PreallocatedLinearOperator methods

### DIFF
--- a/src/PreallocatedLinearOperators.jl
+++ b/src/PreallocatedLinearOperators.jl
@@ -117,7 +117,7 @@ Constructs a linear operator from a symmetric tridiagonal matrix. If
 its elements are real, it is also Hermitian, otherwise complex
 symmetric.
 """
-function PreallocatedLinearOperator(M :: SymTridiagonal{T}; storagetype=Vector{T}) where T
+function PreallocatedLinearOperator(M :: SymTridiagonal{T}; storagetype=Vector{T}, kwargs...) where T
   nrow, ncol = size(M)
   Mv = storagetype(undef, nrow)
   hermitian = eltype(M) <: Real
@@ -132,7 +132,7 @@ Constructs a linear operator from a symmetric matrix. If
 its elements are real, it is also Hermitian, otherwise complex
 symmetric.
 """
-function PreallocatedLinearOperator(M :: Symmetric{T}; storagetype=Vector{T}) where T
+function PreallocatedLinearOperator(M :: Symmetric{T}; storagetype=Vector{T}, kwargs...) where T
   nrow, ncol = size(M)
   Mv = storagetype(undef, nrow)
   hermitian = eltype(M) <: Real
@@ -146,7 +146,7 @@ end
 Constructs a linear operator from a Hermitian matrix. If
 its elements are real, it is also symmetric.
 """
-function PreallocatedLinearOperator(M :: Hermitian{T}; storagetype=Vector{T}) where T
+function PreallocatedLinearOperator(M :: Hermitian{T}; storagetype=Vector{T}, kwargs...) where T
   nrow, ncol = size(M)
   Mv = storagetype(undef, nrow)
   symmetric = eltype(M) <: Real


### PR DESCRIPTION
In Krylov.jl, we cannot use `Symmetric` matrices because `PreallocatedLinearOperator(M ::Symmetric{T}; storagetype, symmetric)` is not implemented.

This PR allows the use of symmetric and hermitian options even if they are not used with `Symmetric`, `Hermitian` and `SymTriadiagonal` wrappers.

https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/src/variants.jl#L24
https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/src/variants.jl#L62
https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/src/variants.jl#L65
https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/src/variants.jl#L73
https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/src/variants.jl#L76