### PR TITLE
Remove typeassert

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -4,7 +4,7 @@ import Base.+, Base.-, Base.*, LinearAlgebra.mul!
 function *(op :: AbstractLinearOperator{T}, v :: AbstractVector{S}) where {T,S}
   size(v, 1) == size(op, 2) || throw(LinearOperatorException("shape mismatch"))
   increase_nprod(op)
-  op.prod(v)::typeof(v).name.wrapper{promote_type(T,S), typeof(v).parameters[2]}
+  op.prod(v)
 end
 
 # Unary operations.

--- a/test/test_linop.jl
+++ b/test/test_linop.jl
@@ -502,7 +502,7 @@ function test_linop()
     @test A == Matrix(opC)
     opF = LinearOperator(Float64, 2, 2, false, false, prod, tprod, ctprod) # The type is a lie
     @test eltype(opF) == Float64
-    @test_throws TypeError Matrix(opF)
+    @test_throws InexactError Matrix(opF)
   end
 
   # Issue #80


### PR DESCRIPTION
The typeassert prevents multiplying with views and makes it
impossible to pass a LinearOperator to Arpack, among others.

closes #154