### PR TITLE
Improve LBFGS allocation

### DIFF
--- a/src/lbfgs.jl
+++ b/src/lbfgs.jl
@@ -222,21 +222,21 @@ function push!(op::LBFGSOperator, s::Vector, y::Vector, α::Real = 1.0, g::Vecto
 
   # Update arrays a and b used in forward products.
   if !op.inverse
-    data.b[insert] .= y / sqrt(ys)
+    @. data.b[insert] = y / sqrt(ys)
 
     for i = 1:(data.mem)
       k = mod(insert + i - 1, data.mem) + 1
       if data.ys[k] != 0
-        data.a[k] .= data.s[k] / data.scaling_factor  # B₀ = I / γ.
+        @. data.a[k] = data.s[k] / data.scaling_factor  # B₀ = I / γ.
 
         for j = 1:(i - 1)
           l = mod(insert + j - 1, data.mem) + 1
           if data.ys[l] != 0
-            data.a[k] .+= dot(data.b[l], data.s[k]) * data.b[l]
-            data.a[k] .-= dot(data.a[l], data.s[k]) * data.a[l]
+            data.a[k] .+= dot(data.b[l], data.s[k]) .* data.b[l]
+            data.a[k] .-= dot(data.a[l], data.s[k]) .* data.a[l]
           end
         end
-        data.a[k] /= sqrt(dot(data.s[k], data.a[k]))
+        data.a[k] ./= sqrt(dot(data.s[k], data.a[k]))
       end
     end
   end

--- a/test/test_lbfgs.jl
+++ b/test/test_lbfgs.jl
@@ -185,6 +185,16 @@ function test_lbfgs()
     @test nallocs == 0
     nallocs = @allocated diag!(B, x)
     @test nallocs == 0
+    y = rand(n)
+    z = Float64[]
+    nallocs = @allocated push!(B, x, y)
+    @test nallocs == 80
+    nallocs = @allocated push!(H, x, y)
+    @test nallocs == 80
+    nallocs = @allocated push!(B, x, y, 0.0, z)
+    @test nallocs == 0
+    nallocs = @allocated push!(H, x, y, 0.0, z)
+    @test nallocs == 0
   end
 
   @testset "LBFGS eigenvalues" begin

--- a/test/test_lbfgs.jl
+++ b/test/test_lbfgs.jl
@@ -204,6 +204,28 @@ function test_lbfgs()
     @test nallocs == 0
   end
 
+  @testset "push! errors" begin
+    n = 100
+    mem = 20
+    B = LBFGSOperator(n, mem = mem)
+    H = InverseLBFGSOperator(n, mem = mem)
+    BD = LBFGSOperator(n, mem = mem, damped = true)
+    HD = InverseLBFGSOperator(n, mem = mem, damped = true)
+    s = ones(n)
+    y = ones(n)
+    g = ones(n)
+    Bs = zeros(n)
+    @test_throws ErrorException push!(B, s, y, Bs)
+    @test_throws ErrorException push!(H, s, y, Bs)
+    @test_throws ErrorException push!(HD, s, y, Bs)
+    @test_throws ErrorException push!(B, s, y, 1.0, g)
+    @test_throws ErrorException push!(BD, s, y, 1.0, g)
+    @test_throws ErrorException push!(H, s, y, 1.0, g)
+    @test_throws ErrorException push!(B, s, y, 1.0, g, Bs)
+    @test_throws ErrorException push!(BD, s, y, 1.0, g, Bs)
+    @test_throws ErrorException push!(H, s, y, 1.0, g, Bs)
+  end
+
   @testset "LBFGS eigenvalues" begin
     n = 100
     mem = 20

--- a/test/test_lbfgs.jl
+++ b/test/test_lbfgs.jl
@@ -169,13 +169,19 @@ function test_lbfgs()
     mem = 20
     B = LBFGSOperator(n, mem = mem)
     H = InverseLBFGSOperator(n, mem = mem)
+    BD = LBFGSOperator(n, mem = mem, damped = true)
+    HD = InverseLBFGSOperator(n, mem = mem, damped = true)
     for _ = 1:2:n
       s = rand(n)
       y = rand(n)
       push!(B, s, y)
       push!(H, s, y)
+      g = rand(n)
+      push!(BD, s, y)
+      push!(HD, s, y, 1.0, g)
     end
     x = rand(n)
+    y = rand(n)
     res = similar(x)
     mul!(res, B, x)  # warmup
     nallocs = @allocated mul!(res, B, x)
@@ -185,15 +191,16 @@ function test_lbfgs()
     @test nallocs == 0
     nallocs = @allocated diag!(B, x)
     @test nallocs == 0
-    y = rand(n)
-    z = Float64[]
+
     nallocs = @allocated push!(B, x, y)
-    @test nallocs == 80
-    nallocs = @allocated push!(H, x, y)
-    @test nallocs == 80
-    nallocs = @allocated push!(B, x, y, 0.0, z)
     @test nallocs == 0
-    nallocs = @allocated push!(H, x, y, 0.0, z)
+    nallocs = @allocated push!(H, x, y)
+    @test nallocs == 0
+
+    tmp = zeros(n)
+    nallocs = @allocated push!(BD, x, y, tmp)
+    @test nallocs == 0
+    nallocs = @allocated push!(HD, x, y, 1.0, x, tmp)
     @test nallocs == 0
   end
 


### PR DESCRIPTION
Notice that `push(nlp, s, y)` allocates 80, possibly due to the default `g = eltype(y)[]`?