### PR TITLE
GPU compat with composite operators and 3-args mul!

### DIFF
--- a/src/TimedOperators.jl
+++ b/src/TimedOperators.jl
@@ -46,6 +46,7 @@ for fn ∈ (
   :nprod,
   :ntprod,
   :nctprod,
+  :storage_type,
   :increase_nprod,
   :increase_ntprod,
   :increase_nctprod,

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -166,6 +166,7 @@ isallocated5(op::AbstractLinearOperator) = op.allocated5
 has_args5(op::AbstractMatrix) = true  # Needed for BlockDiagonalOperator
 
 storage_type(op::LinearOperator) = typeof(op.Mv5)
+storage_type(M::AbstractMatrix{T}) where {T} = Vector{T}
 
 """
   reset!(op)

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -68,10 +68,10 @@ function LinearOperator{T}(
   ctprod!::Fct,
   nprod::I,
   ntprod::I,
-  nctprod::I,
+  nctprod::I;
+  S::DataType = Vector{T},
 ) where {T, I <: Integer, F, Ft, Fct}
-  Mv5, Mtu5 = T[], T[]
-  S = typeof(Mv5)
+  Mv5, Mtu5 = S[], S[]
   nargs = get_nargs(prod!)
   args5 = (nargs == 4)
   (args5 == false) || (nargs != 2) || throw(LinearOperatorException("Invalid number of arguments"))
@@ -103,9 +103,10 @@ LinearOperator{T}(
   hermitian::Bool,
   prod!,
   tprod!,
-  ctprod!,
+  ctprod!;
+  S::DataType = Vector{T},
 ) where {T, I <: Integer} =
-  LinearOperator{T}(nrow, ncol, symmetric, hermitian, prod!, tprod!, ctprod!, 0, 0, 0)
+  LinearOperator{T}(nrow, ncol, symmetric, hermitian, prod!, tprod!, ctprod!, 0, 0, 0, S = S)
 
 # create operator from other operators with +, *, vcat,...
 function CompositeLinearOperator(
@@ -117,10 +118,10 @@ function CompositeLinearOperator(
   prod!::F,
   tprod!::Ft,
   ctprod!::Fct,
-  args5::Bool,
+  args5::Bool;
+  S::DataType = Vector{T},
 ) where {I <: Integer, F, Ft, Fct}
-  Mv5, Mtu5 = T[], T[]
-  S = typeof(Mv5)
+  Mv5, Mtu5 = S[], S[]
   allocated5 = true
   use_prod5! = true
   return LinearOperator{T, I, F, Ft, Fct, S}(
@@ -163,6 +164,8 @@ use_prod5!(op::AbstractLinearOperator) = op.use_prod5!
 isallocated5(op::AbstractLinearOperator) = op.allocated5
 
 has_args5(op::AbstractMatrix) = true  # Needed for BlockDiagonalOperator
+
+storage_type(op::LinearOperator) = typeof(op.Mv5)
 
 """
   reset!(op)

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -71,7 +71,7 @@ function LinearOperator{T}(
   nctprod::I;
   S::DataType = Vector{T},
 ) where {T, I <: Integer, F, Ft, Fct}
-  Mv5, Mtu5 = S[], S[]
+  Mv5, Mtu5 = S(undef, 0), S(undef, 0)
   nargs = get_nargs(prod!)
   args5 = (nargs == 4)
   (args5 == false) || (nargs != 2) || throw(LinearOperatorException("Invalid number of arguments"))
@@ -121,7 +121,7 @@ function CompositeLinearOperator(
   args5::Bool;
   S::DataType = Vector{T},
 ) where {I <: Integer, F, Ft, Fct}
-  Mv5, Mtu5 = S[], S[]
+  Mv5, Mtu5 = S(undef, 0), S(undef, 0)
   allocated5 = true
   use_prod5! = true
   return LinearOperator{T, I, F, Ft, Fct, S}(

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -65,7 +65,7 @@ size(A::ConjugateLinearOperator) = size(A.parent)
 size(A::ConjugateLinearOperator, d::Int) = size(A.parent, d)
 
 for f in
-    [:ishermitian, :issymmetric, :has_args5, :use_prod5!, :isallocated5, :allocate_vectors_args3!]
+    [:ishermitian, :issymmetric, :has_args5, :use_prod5!, :isallocated5, :allocate_vectors_args3!, :storage_type]
   @eval begin
     $f(A::AdjTrans) = $f(A.parent)
     $f(A::ConjugateLinearOperator) = $f(A.parent)

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -38,14 +38,14 @@ function hcat(A::AbstractLinearOperator, B::AbstractLinearOperator)
   nrow = size(A, 1)
   Ancol, Bncol = size(A, 2), size(B, 2)
   ncol = Ancol + Bncol
-  S = promote_type(eltype(A), eltype(B))
+  T = promote_type(eltype(A), eltype(B))
   prod! = @closure (res, v, α, β) -> hcat_prod!(res, A, B, Ancol, Ancol + Bncol, v, α, β)
   tprod! = @closure (res, u, α, β) ->
     hcat_ctprod!(res, transpose(A), transpose(B), Ancol, Ancol + Bncol, u, α, β)
   ctprod! = @closure (res, w, α, β) ->
     hcat_ctprod!(res, adjoint(A), adjoint(B), Ancol, Ancol + Bncol, w, α, β)
   args5 = (has_args5(A) && has_args5(B))
-  CompositeLinearOperator(S, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5)
+  CompositeLinearOperator(T, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5, S = storage_type(A))
 end
 
 function hcat(ops::AbstractLinearOperator...)
@@ -94,14 +94,14 @@ function vcat(A::AbstractLinearOperator, B::AbstractLinearOperator)
   Anrow, Bnrow = size(A, 1), size(B, 1)
   nrow = Anrow + Bnrow
   ncol = size(A, 2)
-  S = promote_type(eltype(A), eltype(B))
+  T = promote_type(eltype(A), eltype(B))
   prod! = @closure (res, v, α, β) -> vcat_prod!(res, A, B, Anrow, Anrow + Bnrow, v, α, β)
   tprod! = @closure (res, u, α, β) ->
     vcat_ctprod!(res, transpose(A), transpose(B), Anrow, Anrow + Bnrow, u, α, β)
   ctprod! = @closure (res, w, α, β) ->
     vcat_ctprod!(res, adjoint(A), adjoint(B), Anrow, Anrow + Bnrow, w, α, β)
   args5 = (has_args5(A) && has_args5(B))
-  CompositeLinearOperator(S, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5)
+  CompositeLinearOperator(T, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5, S = storage_type(A))
 end
 
 function vcat(ops::AbstractLinearOperator...)

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -45,7 +45,9 @@ function hcat(A::AbstractLinearOperator, B::AbstractLinearOperator)
   ctprod! = @closure (res, w, α, β) ->
     hcat_ctprod!(res, adjoint(A), adjoint(B), Ancol, Ancol + Bncol, w, α, β)
   args5 = (has_args5(A) && has_args5(B))
-  CompositeLinearOperator(T, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5, S = storage_type(A))
+  S = promote_type(storage_type(A), storage_type(B))
+  isconcretetype(S) || throw(LinearOperatorException("storage types cannot be promoted to a concrete type"))
+  CompositeLinearOperator(T, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5, S = S)
 end
 
 function hcat(ops::AbstractLinearOperator...)
@@ -101,7 +103,9 @@ function vcat(A::AbstractLinearOperator, B::AbstractLinearOperator)
   ctprod! = @closure (res, w, α, β) ->
     vcat_ctprod!(res, adjoint(A), adjoint(B), Anrow, Anrow + Bnrow, w, α, β)
   args5 = (has_args5(A) && has_args5(B))
-  CompositeLinearOperator(T, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5, S = storage_type(A))
+  S = promote_type(storage_type(A), storage_type(B))
+  isconcretetype(S) || throw(LinearOperatorException("storage types cannot be promoted to a concrete type"))
+  CompositeLinearOperator(T, nrow, ncol, false, false, prod!, tprod!, ctprod!, args5, S = S)
 end
 
 function vcat(ops::AbstractLinearOperator...)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -4,7 +4,7 @@
 Construct a linear operator from a dense or sparse matrix.
 Use the optional keyword arguments to indicate whether the operator
 is symmetric and/or hermitian.
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 function LinearOperator(M::AbstractMatrix{T}; symmetric = false, hermitian = false, S = Vector{T}) where {T}
   nrow, ncol = size(M)
@@ -18,7 +18,7 @@ end
   LinearOperator(M::Symmetric{T}, S = Vector{T}) where {T <: Real} =
 
 Construct a linear operator from a symmetric real square matrix `M`.
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 LinearOperator(M::Symmetric{T}, S = Vector{T}) where {T <: Real} = 
   LinearOperator(M, symmetric = true, hermitian = true, S = S)
@@ -29,7 +29,7 @@ LinearOperator(M::Symmetric{T}, S = Vector{T}) where {T <: Real} =
 Constructs a linear operator from a symmetric tridiagonal matrix. If
 its elements are real, it is also Hermitian, otherwise complex
 symmetric.
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 function LinearOperator(M::SymTridiagonal{T}, S = Vector{T}) where {T}
   hermitian = eltype(M) <: Real
@@ -41,7 +41,7 @@ end
     
 Constructs a linear operator from a Hermitian matrix. If
 its elements are real, it is also symmetric.
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 function LinearOperator(M::Hermitian{T}, S = Vector{T}) where {T}
   symmetric = eltype(M) <: Real
@@ -54,7 +54,7 @@ end
                     S = Vector{T}) where {T}
                     
 Construct a linear operator from functions where the type is specified as the first argument.
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 Notice that the linear operator does not enforce the type, so using a wrong type can
 result in errors. For instance,
 ```

--- a/src/lbfgs.jl
+++ b/src/lbfgs.jl
@@ -92,6 +92,7 @@ LBFGSOperator{T}(
 has_args5(op::LBFGSOperator) = true
 use_prod5!(op::LBFGSOperator) = true
 isallocated5(op::LBFGSOperator) = true
+storage_type(op::LBFGSOperator{T}) where {T} = Vector{T}
 
 """
     InverseLBFGSOperator(T, n, [mem=5; scaling=true])

--- a/src/lsr1.jl
+++ b/src/lsr1.jl
@@ -82,6 +82,7 @@ LSR1Operator{T}(
 has_args5(op::LSR1Operator) = true
 use_prod5!(op::LSR1Operator) = true
 isallocated5(op::LSR1Operator) = true
+storage_type(op::LSR1Operator{T}) where {T} = Vector{T}
 
 """
     LSR1Operator(T, n; [mem=5, scaling=false)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -87,7 +87,7 @@ function *(op1::AbstractLinearOperator, op2::AbstractLinearOperator)
     throw(LinearOperatorException("shape mismatch"))
   end
   S = promote_type(storage_type(op1), storage_type(op2))
-  isconcretetype(S) || throw(LinearOperatorException("promote_type(op1, op2) is not concrete"))
+  isconcretetype(S) || throw(LinearOperatorException("storage types cannot be promoted to a concrete type"))
   #tmp vector for products
   vtmp = fill!(S(undef, m2), zero(T))
   utmp = fill!(S(undef, n1), zero(T))
@@ -157,7 +157,7 @@ function +(op1::AbstractLinearOperator, op2::AbstractLinearOperator)
   herm = (ishermitian(op1) && ishermitian(op2))
   args5 = (has_args5(op1) && has_args5(op2))
   S = promote_type(storage_type(op1), storage_type(op2))
-  isconcretetype(S) || throw(LinearOperatorException("promote_type(op1, op2) is not concrete"))
+  isconcretetype(S) || throw(LinearOperatorException("storage types cannot be promoted to a concrete type"))
   return CompositeLinearOperator(T, m1, n1, symm, herm, prod!, tprod!, ctprod!, args5, S = S)
 end
 

--- a/src/special-operators.jl
+++ b/src/special-operators.jl
@@ -40,7 +40,7 @@ end
     opEye(n)
 
 Identity operator of order `n` and of data type `T` (defaults to `Float64`).
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 function opEye(T::DataType, n::Int; S = Vector{T})
   prod! = @closure (res, v, α, β) -> mulOpEye!(res, v, α, β, n)
@@ -56,7 +56,7 @@ opEye(n::Int) = opEye(Float64, n)
 
 Rectangular identity operator of size `nrow`x`ncol` and of data type `T`
 (defaults to `Float64`).
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 function opEye(T::DataType, nrow::I, ncol::I; S = Vector{T}) where {I <: Integer}
   if nrow == ncol
@@ -82,7 +82,7 @@ end
 
 Operator of all ones of size `nrow`-by-`ncol` of data type `T` (defaults to
 `Float64`).
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 function opOnes(T::DataType, nrow::I, ncol::I; S = Vector{T}) where {I <: Integer}
   prod! = @closure (res, v, α, β) -> mulOpOnes!(res, v, α, β)
@@ -105,7 +105,7 @@ end
 
 Zero operator of size `nrow`-by-`ncol`, of data type `T` (defaults to
 `Float64`).
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
 function opZeros(T::DataType, nrow::I, ncol::I; S = Vector{T}) where {I <: Integer}
   prod! = @closure (res, v, α, β) -> mulOpZeros!(res, v, α, β)
@@ -223,7 +223,7 @@ end
 eltypeof(op::AbstractLinearOperator) = eltype(op)  # need this for promote_eltypeof
 
 """
-    BlockDiagonalOperator(M1, M2, ..., Mn; S = Vector{eltype(ops[1])})
+    BlockDiagonalOperator(M1, M2, ..., Mn; S = Vector{promote_type(eltype.(M1, M2, ..., Mn))})
 
 Creates a block-diagonal linear operator:
 
@@ -232,9 +232,9 @@ Creates a block-diagonal linear operator:
     [       ...    ]
     [           Mn ]
 
-Change `S` if want to use LinearOperators on GPU.
+Change `S` to use LinearOperators on GPU.
 """
-function BlockDiagonalOperator(ops...; S = Vector{eltype(ops[1])})
+function BlockDiagonalOperator(ops...; S = Vector{promote_type(eltype.(ops)...)})
   nrow = ncol = 0
   for op ∈ ops
     m, n = size(op)

--- a/src/special-operators.jl
+++ b/src/special-operators.jl
@@ -223,7 +223,7 @@ end
 eltypeof(op::AbstractLinearOperator) = eltype(op)  # need this for promote_eltypeof
 
 """
-    BlockDiagonalOperator(M1, M2, ..., Mn; S = Vector{promote_type(eltype.(M1, M2, ..., Mn))})
+    BlockDiagonalOperator(M1, M2, ..., Mn; S = promote_type(storage_type.(M1, M2, ..., Mn)))
 
 Creates a block-diagonal linear operator:
 
@@ -234,7 +234,7 @@ Creates a block-diagonal linear operator:
 
 Change `S` to use LinearOperators on GPU.
 """
-function BlockDiagonalOperator(ops...; S = Vector{promote_type(eltype.(ops)...)})
+function BlockDiagonalOperator(ops...; S = promote_type(storage_type.(ops)...))
   nrow = ncol = 0
   for op ∈ ops
     m, n = size(op)


### PR DESCRIPTION
This is a PR to make LinearOperators such as  `op = op1 * op2`, `op = op1 + op2` ... and the 5-args `mul!` function from operators build upon the 3-args `mul!`  work on GPU.
The user has to specify the storage type in the constructor of all operators `op1` and `op2`:
```julia
op1 = LinearOperator(Float64, n, n, true, true, prod!, S = CuVector{Float64, 1, CUDA.Mem.DeviceBuffer})
```
Operators that are not "composite" (built with other operators) should already be working without this PR.
