### PR TITLE
Reduce allocations in normest

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -34,10 +34,10 @@ function normest(S, tol = -1, maxiter = 100)
 
   x ./= e
   e_0 = zero(e)
-
+  Sx = zeros(eltype(S), n)
+  
   while abs(e - e_0) > tol * e
     e_0 = e
-    Sx = zeros(eltype(S), n)
     mul!(Sx, S, x)
     if count(x -> x != 0, Sx) == 0
       Sx .= randn(eltype(Sx), size(Sx))


### PR DESCRIPTION
moving the     Sx = zeros(eltype(S), n) out of the loop