### PR TITLE
Potential Bugfix

### DIFF
--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -165,7 +165,7 @@ isallocated5(op::AbstractLinearOperator) = op.allocated5
 
 has_args5(op::AbstractMatrix) = true  # Needed for BlockDiagonalOperator
 
-storage_type(op::LinearOperator) = typeof(op.Mv5)
+storage_type(op::AbstractLinearOperator) = typeof(op.Mv5) # Need abstract for arbitrary, user defined operators
 storage_type(M::AbstractMatrix{T}) where {T} = Vector{T}
 
 """

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -165,7 +165,10 @@ isallocated5(op::AbstractLinearOperator) = op.allocated5
 
 has_args5(op::AbstractMatrix) = true  # Needed for BlockDiagonalOperator
 
-storage_type(op::AbstractLinearOperator) = typeof(op.Mv5) # Need abstract for arbitrary, user defined operators
+# Alert user of the need for storage_type method definition for arbitrary, user defined operators
+storage_type(op::AbstractLinearOperator) = error("please implement storage_type for $(typeof(op))")
+
+storage_type(op::LinearOperator) = typeof(op.Mv5) 
 storage_type(M::AbstractMatrix{T}) where {T} = Vector{T}
 
 """


### PR DESCRIPTION
For externally defined operator types (i.e NFFTOp in MRIReco.jl) the following error is encountered: 
```

MethodError: no method matching storage_type(::NFFTOp{ComplexF64})
[371](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:371)
  Closest candidates are:
[372](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:372)
    storage_type(::LinearOperator) at /home/runner/.julia/packages/LinearOperators/ER4po/src/abstract.jl:168
[373](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:373)
    storage_type(::AbstractMatrix{T}) where T at /home/runner/.julia/packages/LinearOperators/ER4po/src/abstract.jl:169
[374](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:374)
    storage_type(::Union{AdjointLinearOperator, TransposeLinearOperator}) at /home/runner/.julia/packages/LinearOperators/ER4po/src/adjtrans.jl:77
[375](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:375)
    ...
[376](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:376)
  Stacktrace:
[377](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:377)
    [1] storage_type(A::AdjointLinearOperator{ComplexF64, NFFTOp{ComplexF64}})
[378](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:378)
      @ LinearOperators ~/.julia/packages/LinearOperators/ER4po/src/adjtrans.jl:77
[379](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:379)
    [2] *(op1::AdjointLinearOperator{ComplexF64, NFFTOp{ComplexF64}}, op2::NFFTOp{ComplexF64})
[380](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:380)
      @ LinearOperators ~/.julia/packages/LinearOperators/ER4po/src/operations.jl:118
[381](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:381)
    [3] *(::AdjointLinearOperator{ComplexF64, NFFTOp{ComplexF64}}, ::NFFTOp{ComplexF64}, ::Vector{ComplexF64})
[382](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:382)
      @ Base ./operators.jl:560
[383](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:383)
    [4] testFT(N::Int64)
[384](https://github.com/MagneticResonanceImaging/MRIReco.jl/runs/6123878388?check_suite_focus=true#step:6:384)
      @ Main ~/work/MRIReco.jl/MRIReco.jl/test/testOperators.jl:47
```

The proposed change seems to fix the issue, but I was wondering if the function argument being the base LinearOperator type was a design decision (since we can also fix the issue by locally overloading the LinearOperator.storage_type function for each external operator). 