### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -41,7 +41,7 @@ The optional `check` argument will perform cheap hermicity and definiteness
 checks.
 This Operator is not in-place when using `mul!`.
 """
-function opCholesky(M::AbstractMatrix; check::Bool = false) where {T}
+function opCholesky(M::AbstractMatrix; check::Bool = false)
   (m, n) = size(M)
   m == n || throw(LinearOperatorException("shape mismatch"))
   if check
@@ -71,7 +71,7 @@ If M is sparse and real, then only the upper triangle should be stored in order 
     opLDL(Symmetric(M, :U))
 
 """
-function opLDL(M::AbstractMatrix; check::Bool = false) where {T}
+function opLDL(M::AbstractMatrix; check::Bool = false)
   (m, n) = size(M)
   m == n || throw(LinearOperatorException("shape mismatch"))
   if check

--- a/src/special-operators.jl
+++ b/src/special-operators.jl
@@ -176,7 +176,7 @@ The operation `Z * v` is equivalent to `v[I]`. `I` can be `:`.
 
 Alias for `opRestriction([k], ncol)`.
 """
-function opRestriction(Idx::LinearOperatorIndexType{I}, ncol::I) where {T, I <: Integer}
+function opRestriction(Idx::LinearOperatorIndexType{I}, ncol::I) where {I <: Integer}
   all(1 .≤ Idx .≤ ncol) || throw(LinearOperatorException("indices should be between 1 and $ncol"))
   nrow = length(Idx)
   prod! = @closure (res, v, α, β) -> mulRestrict!(res, Idx, v, α, β)


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this isn't merely cosmetic.

FTR, there's a relevant function in Test in stdlib for checking this stuff:
https://docs.julialang.org/en/v1/stdlib/Test/#Test.detect_unbound_args