### PR TITLE
fix for Kronecker product scaling

### DIFF
--- a/src/kron.jl
+++ b/src/kron.jl
@@ -15,27 +15,27 @@ function kron(A::AbstractLinearOperator, B::AbstractLinearOperator)
     S = promote_type(T, eltype(x))
     X = reshape(convert(Vector{S}, x), q, n)
     if β == zero(T2)
-      res .= Matrix(B * X * transpose(A))[:]
+      res .= α .* Matrix(B * X * transpose(A))[:]
     else
-      res .= Matrix(B * X * transpose(A))[:] .+ β .* res
+      res .= α .* Matrix(B * X * transpose(A))[:] .+ β .* res
     end
   end
   function tprod!(res, x, α, β::T2) where {T2}
     S = promote_type(T, eltype(x))
     X = reshape(convert(Vector{S}, x), p, m)
     if β == zero(T2)
-      res .= Matrix(transpose(B) * X * A)[:]
+      res .= α .* Matrix(transpose(B) * X * A)[:]
     else
-      res .= Matrix(transpose(B) * X * A)[:] .+ β .* res
+      res .= α .* Matrix(transpose(B) * X * A)[:] .+ β .* res
     end
   end
   function ctprod!(res, x, α, β::T2) where {T2}
     S = promote_type(T, eltype(x))
     X = reshape(convert(Vector{S}, x), p, m)
     if β == zero(T2)
-      res .= Matrix(B' * X * conj(A))[:]
+      res .= α .* Matrix(B' * X * conj(A))[:]
     else
-      res .= Matrix(B' * X * conj(A))[:] .+ β .* res
+      res .= α .* Matrix(B' * X * conj(A))[:] .+ β .* res
     end
   end
   symm = issymmetric(A) && issymmetric(B)

--- a/test/test_kron.jl
+++ b/test/test_kron.jl
@@ -46,6 +46,16 @@ function test_kron()
     y = K * x
     @test eltype(y) == Complex{Float64}
   end
+
+  @testset ExtendedTestSet "kron scaling" begin
+   A =2kron(opEye(2),I(1))
+   x = randn(2)
+   y1=A*x
+   y2=A'*x
+   y3=transpose(A)*x
+   err = norm(y1-2x) + norm(y2-2x) + norm(y3-2x)
+   @test err < 1e-12
+  end
 end
 
 test_kron()


### PR DESCRIPTION
The Kronecker product code currently does not deal with multiplication by scalars correctly. This is illustrated below:
```julia
using LinearOperators, LinearAlgebra
A = kron(opEye(2),I(1))
Matrix(2A)
```
This results in:
```
2×2 Matrix{Float64}:
 1.0  0.0
 0.0  1.0
```
when it should be 2 times identity.