### PR TITLE
Add reset function for Diagonal QN operators, fix bug SpectralGradient

### DIFF
--- a/src/DiagonalHessianApproximation.jl
+++ b/src/DiagonalHessianApproximation.jl
@@ -79,7 +79,7 @@ function push!(
 end
 
 """
-    reset!(op)
+    reset!(op::DiagonalQN)
 Resets the DiagonalQN data of the given operator.
 """
 function reset!(op::DiagonalQN{T}) where {T <: Real}
@@ -149,7 +149,7 @@ function push!(
 end
 
 """
-    reset!(op)
+    reset!(op::SpectralGradient)
 Resets the SpectralGradient data of the given operator.
 """
 function reset!(op::SpectralGradient{T}) where {T <: Real}

--- a/test/test_diag.jl
+++ b/test/test_diag.jl
@@ -63,7 +63,7 @@ end
       Bref = -5 / 2
     end
     push!(B, s, y)
-    @test abs(B.d - Bref) <= 1e-10
+    @test abs(B.d[1] - Bref) <= 1e-10
   end
 end
 
@@ -80,4 +80,20 @@ end
   C = SpectralGradient(rand(), 5)
   mul!(u, C, v)
   @test (@allocated mul!(u, C, v)) == 0
+end
+
+@testset "reset" begin
+  B = DiagonalQN([1.0, -1.0, 1.0], false)
+  s = x1 - x0
+  y = ∇f(x1) - ∇f(x0)
+  push!(B, s, y)
+  reset!(B)
+  @test B * x0 == x0
+
+  B = SpectralGradient(2.5, 3)
+  s = x1 - x0
+  y = ∇f(x1) - ∇f(x0)
+  push!(B, s, y)
+  reset!(B)
+  @test B * x0 == x0
 end


### PR DESCRIPTION
Following https://github.com/JuliaSmoothOptimizers/NLPModelsModifiers.jl/pull/94, I added `reset!` functions that restore the QN operators to the identity operator.

At the same time, I spotted a bug with `SpectralGradient` where the push was not updating `d` in the closure `prod = (res, v, α, β) -> mulSquareOpDiagonal!(res, d, v, α, β)` (because `d` was a Real).
I fixed it by changing `d` to `[σ]` so that modifying `d[1]` modifies `mulSquareOpDiagonal!(res, d, v, α, β)` accordingly.

This modifies the way we update a `SpectralGradient`: we have to do `op.d[1] = 2.0` instead of `op.d = 2.0`, but since we are supposed to update this operator with `push!`, this should not break code.

Does the adding of the `reset!` function requires a new minor release `2.6.0`, or can we stick to a patch `2.5.1`?