### PR TITLE
Improve DiagonalQN stability when s is close to zero

### DIFF
--- a/src/DiagonalHessianApproximation.jl
+++ b/src/DiagonalHessianApproximation.jl
@@ -17,6 +17,9 @@ https://doi.org/10.1007/s11075-018-0562-7
 mutable struct DiagonalQN{T <: Real, I <: Integer, V <: AbstractVector{T}, F} <:
                AbstractDiagonalQuasiNewtonOperator{T}
   d::V # Diagonal of the operator
+  s::V
+  s2::V
+  y::V
   nrow::I
   ncol::I
   symmetric::Bool
@@ -47,7 +50,11 @@ positive definite.
 """
 function DiagonalQN(d::AbstractVector{T}, psb::Bool = false) where {T <: Real}
   prod = (res, v, α, β) -> mulSquareOpDiagonal!(res, d, v, α, β)
-  DiagonalQN(d, length(d), length(d), true, true, prod, prod, prod, 0, 0, 0, true, true, true, psb)
+  n = length(d)
+  s = similar(d)
+  s2 = similar(d)
+  y = similar(d)
+  DiagonalQN(d, s, s2, y, n, n, true, true, prod, prod, prod, 0, 0, 0, true, true, true, psb)
 end
 
 # update function
@@ -55,14 +62,21 @@ end
 # y = ∇f(x_{k+1}) - ∇f(x_k)
 function push!(
   B::DiagonalQN{T, I, V, F},
-  s::V,
-  y::V,
+  s0::V,
+  y0::V,
 ) where {T <: Real, I <: Integer, V <: AbstractVector{T}, F}
-  s2 = (si^2 for si ∈ s)
-  trA2 = dot(s2, s2)
-  if trA2 == 0
-    error("Cannot divide by zero and trA2 = 0")
+  s = B.s
+  s2 = B.s2
+  y = B.y
+  s0Norm = norm(s0, 2)
+  if s0Norm == 0
+    error("Cannot update DiagonalQN operator with s=0")
   end
+  # sᵀBs = sᵀy can be scaled by ||s||² without changing the updating problem
+  s .= s0 ./ s0Norm
+  y .= y0 ./ s0Norm
+  s2 .= s .^ 2
+  trA2 = dot(s2, s2)
   sT_y = dot(s, y)
   sT_B_s = dot(s2, B.d)
   q = sT_y - sT_B_s


### PR DESCRIPTION
This PR essentially consists of dividing the equation

$$s^T B s = s^T y$$ 

in the QN update by $||s||_2^2$ to handle better small $s$ values. I put some storage vectors in the `DiagonalQN` struct to avoid allocating them at every `push!` call.