### PR TITLE
[breaking] Remove shape function (duplicate of size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Function           | Description
 `hermitian`        | Determine whether the operator is Hermitian
 `push!`            | For L-BFGS or L-SR1 operators, push a new pair {s,y}
 `reset!`           | For L-BFGS or L-SR1 operators, reset the data
-`shape`            | Return the size of a linear operator
 `show`             | Display basic information about an operator
 `size`             | Return the size of a linear operator
 `symmetric`        | Determine whether the operator is symmetric

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -51,7 +51,6 @@ Function           | Description
 `hermitian`        | Determine whether the operator is Hermitian
 `push!`            | For L-BFGS or L-SR1 operators, push a new pair {s,y}
 `reset!`           | For L-BFGS or L-SR1 operators, reset the data
-`shape`            | Return the size of a linear operator
 `show`             | Display basic information about an operator
 `size`             | Return the size of a linear operator
 `symmetric`        | Determine whether the operator is symmetric

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -12,8 +12,7 @@ export AbstractLinearOperator,
   nprod,
   ntprod,
   nctprod,
-  reset!,
-  shape
+  reset!
 
 mutable struct LinearOperatorException <: Exception
   msg::AbstractString
@@ -209,13 +208,6 @@ function size(op::AbstractLinearOperator, d::Integer)
   end
   throw(LinearOperatorException("Linear operators only have 2 dimensions for now"))
 end
-
-"""
-    m, n = shape(op)
-
-An alias for size.
-"""
-shape(op::AbstractLinearOperator) = size(op)
 
 """
     ishermitian(op)

--- a/test/test_linop.jl
+++ b/test/test_linop.jl
@@ -20,7 +20,6 @@ function test_linop()
 
       @testset "Size" begin
         @test(size(op) == (nrow, ncol))
-        @test(shape(op) == (nrow, ncol))
         @test(size(op, 1) == nrow)
         @test(size(op, 2) == ncol)
         @test_throws LinearOperatorException size(op, 3)
@@ -676,7 +675,7 @@ function test_linop()
     for _ = 1:nctprods
       op' * rand(3)
     end
-    for fn ∈ (:size, :shape, :issymmetric, :ishermitian, :nprod, :ntprod, :nctprod)
+    for fn ∈ (:size, :issymmetric, :ishermitian, :nprod, :ntprod, :nctprod)
       @eval begin
         @test $fn($top) == $fn($top.op)
       end


### PR DESCRIPTION
Hi everyone,

we have encountered in several of our packages a conflict between the functions `LinearOperators.shape` and `Distributions.shape` (https://github.com/JuliaImageRecon/LinearOperatorCollection.jl/issues/3#issuecomment-1822917316). Since the former is a duplicate of `size`, I was wondering if it would be feasible to drop `shape` from this package. To make everyone's life easier, I put those changes in a PR. 

This change would be breaking as we would drop an exported function. But fixes in other packages should be straight forward with a search & replace. 

Many thanks for considering!
