### PR TITLE
Review julia compatibility in readme #313

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Operators behave like matrices (with some exceptions - see below) but are define
 
 ## Compatibility
 
-Julia 1.6 and up.
+[Julia 1.6](https://julialang.org/downloads/) and up.
 
 ## How to Install
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Operators behave like matrices (with some exceptions - see below) but are define
 
 ## Compatibility
 
-Julia 1.3 and up.
+Julia 1.6 and up.
 
 ## How to Install
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Operators behave like matrices (with some exceptions - see below) but are define
 
 ## Compatibility
 
-[Julia 1.6](https://julialang.org/downloads/) and up.
+[Julia 1.6](https://julialang.org/downloads/#long_term_support_release) and up.
 
 ## How to Install
 


### PR DESCRIPTION
This pull request addresses issue #313 by correcting the Julia version compatibility information in the README. The current README states "Julia 1.3 and up". The corrected version now accurately reflects the correct compatibility as "Julia 1.6 and up."

Changes Made:
* Updated README.md to specify Julia version compatibility as "Julia 1.6 and up" on line 30.

Related Issue:
Closes #313