### PR TITLE
Add LinearOperator constructor for CUDA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,3 +33,5 @@ julia = "^1.6.0"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+

--- a/Project.toml
+++ b/Project.toml
@@ -13,12 +13,15 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [extensions]
 LinearOperatorsChainRulesCoreExt = "ChainRulesCore"
+LinearOperatorsCUDAExt = "CUDA"
 
 [compat]
 ChainRulesCore = "1"
+CUDA = "4, 5"
 FastClosures = "0.2, 0.3"
 LDLFactorizations = "0.9, 0.10"
 LinearAlgebra = "1"

--- a/ext/LinearOperatorsCUDAExt.jl
+++ b/ext/LinearOperatorsCUDAExt.jl
@@ -1,0 +1,19 @@
+module LinearOperatorsCUDAExt
+
+using LinearOperators, LinearOperators.FastClosures, LinearOperators.LinearAlgebra
+isdefined(Base, :get_extension) ? (using CUDA) : (using ..CUDA)
+
+function LinearOperators.LinearOperator(
+  M::CuArray{T, 2, D};
+  symmetric = false,
+  hermitian = false,
+  S = CuArray{T, 1, D},
+) where {T, D}
+  nrow, ncol = size(M)
+  prod! = @closure (res, v, α, β) -> mul!(res, M, v, α, β)
+  tprod! = @closure (res, u, α, β) -> mul!(res, transpose(M), u, α, β)
+  ctprod! = @closure (res, w, α, β) -> mul!(res, adjoint(M), w, α, β)
+  LinearOperators.LinearOperator{T}(nrow, ncol, symmetric, hermitian, prod!, tprod!, ctprod!, S = S)
+end
+
+end # module

--- a/ext/LinearOperatorsCUDAExt.jl
+++ b/ext/LinearOperatorsCUDAExt.jl
@@ -1,19 +1,8 @@
 module LinearOperatorsCUDAExt
 
-using LinearOperators, LinearOperators.FastClosures, LinearOperators.LinearAlgebra
+using LinearOperators
 isdefined(Base, :get_extension) ? (using CUDA) : (using ..CUDA)
 
-function LinearOperators.LinearOperator(
-  M::CuArray{T, 2, D};
-  symmetric = false,
-  hermitian = false,
-  S = CuArray{T, 1, D},
-) where {T, D}
-  nrow, ncol = size(M)
-  prod! = @closure (res, v, α, β) -> mul!(res, M, v, α, β)
-  tprod! = @closure (res, u, α, β) -> mul!(res, transpose(M), u, α, β)
-  ctprod! = @closure (res, w, α, β) -> mul!(res, adjoint(M), w, α, β)
-  LinearOperators.LinearOperator{T}(nrow, ncol, symmetric, hermitian, prod!, tprod!, ctprod!, S = S)
-end
+LinearOperators.storage_type(::CuArray{T, 2, D}) where {T, D} = CuArray{T, 1, D}
 
 end # module

--- a/src/LinearOperators.jl
+++ b/src/LinearOperators.jl
@@ -38,6 +38,9 @@ end
     Requires.@require ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4" begin
       include("../ext/LinearOperatorsChainRulesCoreExt.jl")
     end
+    Requires.@require CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba" begin
+      include("../ext/LinearOperatorsCUDAExt.jl")
+    end
   end
 end
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -10,7 +10,7 @@ function LinearOperator(
   M::AbstractMatrix{T};
   symmetric = false,
   hermitian = false,
-  S = Vector{T},
+  S = storage_type(M)
 ) where {T}
   nrow, ncol = size(M)
   prod! = @closure (res, v, α, β) -> mul!(res, M, v, α, β)


### PR DESCRIPTION
This PR adds a method for the `LinearOperator` function which has a correct default storage type for CUDA's `CuArray`.

This should (partially, it does not fix the upstream error in NLPModels.jl) fix #307, in particular this error is resolved:

```julia
julia> using CUDA, LinearOperators

julia> N = 8
8

julia> A = CUDA.rand(N, N);

julia> x = CUDA.rand(N);

julia> (A + opEye(Float32, N, S = typeof(x)));
ERROR: LinearOperatorException("storage types cannot be promoted to a concrete type")
Stacktrace:
 [1] +(op1::LinearOperator{Float32, Int64, LinearOperators.var"#5#8"{CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}}, LinearOperators.var"#6#9"{CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}}, LinearOperators.var"#7#10"{CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}}, Vector{Float32}}, op2::LinearOperator{Float32, Int64, LinearOperators.var"#135#136"{Int64}, LinearOperators.var"#135#136"{Int64}, LinearOperators.var"#135#136"{Int64}, CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}})
   @ LinearOperators ~/.julia/packages/LinearOperators/lK3j5/src/operations.jl:190
 [2] +(M::CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}, op::LinearOperator{Float32, Int64, LinearOperators.var"#135#136"{Int64}, LinearOperators.var"#135#136"{Int64}, LinearOperators.var"#135#136"{Int64}, CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}})
   @ LinearOperators ~/.julia/packages/LinearOperators/lK3j5/src/operations.jl:196
 [3] top-level scope
   @ REPL[14]:1
 [4] top-level scope
   @ ~/.julia/packages/CUDA/htRwP/src/initialization.jl:206
```

The method is defined in a package extension for CUDA. I've also tried to make it available for older Julia Version with Requires, similar to how it was done for the ChainRulesExt.