### PR TITLE
Add `mul!` for matrices

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -200,6 +200,8 @@ function mul!(
   conj!(res)
 end
 
+# TODO: overload the above for matrices?
+
 -(op::AdjointLinearOperator) = adjoint(-op.parent)
 -(op::TransposeLinearOperator) = transpose(-op.parent)
 -(op::ConjugateLinearOperator) = conj(-op.parent)

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -32,6 +32,8 @@ function hcat_ctprod!(
   mul!(view(res, (Ancol + 1):nV), B, u, α, β)
 end
 
+# TODO: overload the above for matrices?
+
 function hcat(A::AbstractLinearOperator, B::AbstractLinearOperator)
   size(A, 1) == size(B, 1) || throw(LinearOperatorException("hcat: inconsistent row sizes"))
 
@@ -90,6 +92,8 @@ function vcat_ctprod!(
   mul!(res, A, view(v, 1:Anrow), α, β)
   mul!(res, B, view(v, (Anrow + 1):nV), α, one(T))
 end
+
+# TODO: overload the above for matrices?
 
 function vcat(A::AbstractLinearOperator, B::AbstractLinearOperator)
   size(A, 2) == size(B, 2) || throw(LinearOperatorException("vcat: inconsistent column sizes"))

--- a/src/kron.jl
+++ b/src/kron.jl
@@ -44,6 +44,8 @@ function kron(A::AbstractLinearOperator, B::AbstractLinearOperator)
   return LinearOperator{T}(nrow, ncol, symm, herm, prod!, tprod!, ctprod!)
 end
 
+# TODO: overload the above for matrices?
+
 kron(A::AbstractMatrix, B::AbstractLinearOperator) = kron(LinearOperator(A), B)
 
 kron(A::AbstractLinearOperator, B::AbstractMatrix) = kron(A, LinearOperator(B))

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -32,8 +32,17 @@ function mul!(res::AbstractVector, op::AbstractLinearOperator{T}, v::AbstractVec
   end
 end
 
+function mul!(res::AbstractMatrix, op::AbstractLinearOperator{T}, m::AbstractMatrix, α, β) where {T}
+  # TODO: how to handle storage?
+  error("5-argument `mul!` is not defined between a linear operator and a matrix.")
+end
+
 function mul!(res::AbstractVector, op::AbstractLinearOperator, v::AbstractVector{T}) where {T}
   mul!(res, op, v, one(T), zero(T))
+end
+
+function mul!(res::AbstractMatrix, op::AbstractLinearOperator, m::AbstractMatrix{T}) where {T}
+  mul!(res, op, m, one(T), zero(T))
 end
 
 # Apply an operator to a vector.
@@ -73,6 +82,26 @@ function *(
   return v_wrapper(res)
 end
 
+# Apply an operator to a matrix (only in-place, since operator * matrix is a matrix).
+
+function mul!(
+  res::Adjoint{S1, M1},
+  m::Adjoint{S2, M2},
+  op::AbstractLinearOperator{T},
+) where {T, S1, S2, M1 <: AbstractMatrix{S1}, M2 <: AbstractMatrix{S2}}
+  mul!(adjoint(res), adjoint(op), adjoint(m))
+  return res
+end
+
+function mul!(
+  res::Transpose{S1, M1},
+  m::Transpose{S2, M2},
+  op::AbstractLinearOperator{T},
+) where {T, S1, S2, M1 <: AbstractMatrix{S1}, M2 <: AbstractMatrix{S2}}
+  mul!(transpose(res), transpose(op), transpose(m))
+  return res
+end
+
 # Unary operations.
 +(op::AbstractLinearOperator) = op
 
@@ -95,11 +124,11 @@ function -(op::AbstractLinearOperator{T}) where {T}
 end
 
 function prod_op!(
-  res::AbstractVector,
+  res::AbstractVecOrMat,
   op1::AbstractLinearOperator,
   op2::AbstractLinearOperator,
-  vtmp::AbstractVector,
-  v::AbstractVector,
+  vtmp::AbstractVecOrMat,
+  v::AbstractVecOrMat,
   α,
   β,
 )
@@ -162,10 +191,10 @@ end
 # Operator + operator.
 
 function sum_prod!(
-  res::AbstractVector,
+  res::AbstractVecOrMat,
   op1::AbstractLinearOperator,
   op2::AbstractLinearOperator{T},
-  v::AbstractVector,
+  v::AbstractVecOrMat,
   α,
   β,
 ) where {T}

--- a/src/special-operators.jl
+++ b/src/special-operators.jl
@@ -43,6 +43,8 @@ function mulOpEye!(res, v, α, β::T, n_min) where {T}
   end
 end
 
+# TODO: overload the above for matrices?
+
 """
     opEye(T, n; S = Vector{T})
     opEye(n)
@@ -84,6 +86,8 @@ function mulOpOnes!(res, v, α, β::T) where {T}
   end
 end
 
+# TODO: overload the above for matrices?
+
 """
     opOnes(T, nrow, ncol; S = Vector{T})
     opOnes(nrow, ncol)
@@ -106,6 +110,8 @@ function mulOpZeros!(res, v, α, β::T) where {T}
     res .*= β
   end
 end
+
+# TODO: overload the above for matrices?
 
 """
     opZeros(T, nrow, ncol; S = Vector{T})
@@ -130,6 +136,8 @@ function mulSquareOpDiagonal!(res, d, v, α, β::T) where {T}
   end
 end
 
+# TODO: overload the above for matrices?
+
 """
     opDiagonal(d)
 
@@ -149,6 +157,9 @@ function mulOpDiagonal!(res, d, v, α, β::T, n_min) where {T}
   end
   res[(n_min + 1):end] .= 0
 end
+
+# TODO: overload the above for matrices?
+
 """
     opDiagonal(nrow, ncol, d)
 
@@ -172,6 +183,8 @@ function multRestrict!(res, I, u, α, β)
   res .= 0
   res[I] = u
 end
+
+# TODO: overload the above for matrices?
 
 """
     Z = opRestriction(I, ncol)
@@ -289,3 +302,5 @@ function BlockDiagonalOperator(ops...; S = promote_type(storage_type.(ops)...))
   args5 = all((has_args5(op) for op ∈ ops))
   CompositeLinearOperator(T, nrow, ncol, symm, herm, prod!, tprod!, ctprod!, args5, S = S)
 end
+
+# TODO: overload the above for matrices?


### PR DESCRIPTION
Goal: to fix #322 by adding `mul!(res::AbstractMatrix, op::LinearOperator, m::AbstractMatrix)`

In practice, there are lots of things to overload and I don't know if you want to do all of them. I also don't know how you want to test this new functionality. But anyway, here's a first draft (without tests) to get the discussion started