### PR TITLE
Add JLArrays extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,17 +13,20 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"
 
 [extensions]
 LinearOperatorsChainRulesCoreExt = "ChainRulesCore"
 LinearOperatorsCUDAExt = "CUDA"
 LinearOperatorsLDLFactorizationsExt = "LDLFactorizations"
+LinearOperatorsJLArraysExt = "JLArrays"
 
 [compat]
 ChainRulesCore = "1"
 CUDA = "4, 5"
 FastClosures = "0.2, 0.3"
+JLArrays = "0.1"
 LDLFactorizations = "0.9, 0.10"
 LinearAlgebra = "1"
 Printf = "1"
@@ -36,3 +39,4 @@ julia = "^1.6.0"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"

--- a/ext/LinearOperatorsJLArraysExt.jl
+++ b/ext/LinearOperatorsJLArraysExt.jl
@@ -1,0 +1,8 @@
+module LinearOperatorsJLArraysExt
+
+using LinearOperators
+isdefined(Base, :get_extension) ? (using JLArrays) : (using ..JLArrays)
+
+LinearOperators.storage_type(::JLArray{T, 2}) where {T} = JLArray{T, 1}
+
+end # module

--- a/src/LinearOperators.jl
+++ b/src/LinearOperators.jl
@@ -43,6 +43,9 @@ end
     Requires.@require LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b" begin
       include("../ext/LinearOperatorsLDLFactorizationsExt.jl")
     end
+    Requires.@require JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb" begin
+      include("../ext/LinearOperatorsJLArraysExt.jl")
+    end
   end
 end
 


### PR DESCRIPTION
This PR adds a weak extension for [JLArrays](https://github.com/JuliaGPU/GPUArrays.jl/tree/master/lib/JLArrays). These arrays are a CPU-reference-implementation of GPUArrays and allow for easier testing of GPU handling. The weak extension is structured similar to the CUDA extension