### PR TITLE
Add storage_type for Sparse CuArrays

### DIFF
--- a/ext/LinearOperatorsCUDAExt.jl
+++ b/ext/LinearOperatorsCUDAExt.jl
@@ -1,8 +1,9 @@
 module LinearOperatorsCUDAExt
 
 using LinearOperators
-isdefined(Base, :get_extension) ? (using CUDA) : (using ..CUDA)
+isdefined(Base, :get_extension) ? (using CUDA; using CUDA.CUSPARSE) : (using ..CUDA; using ..CUDA.CUSPARSE)
 
 LinearOperators.storage_type(::CuArray{T, 2, D}) where {T, D} = CuArray{T, 1, D}
+LinearOperators.storage_type(::AbstractCuSparseMatrix{T}) where {T} = CuArray{T, 1, CUDA.DeviceMemory}
 
 end # module


### PR DESCRIPTION
This PR implements `storage_type` for sparse `CuArrays. Since `CuArrays` and sparse `CuArrays` have no common CUDA-specific supertype, we have to handle it with a new case.

In the `storage_type` function I had to specify the memory type, unlike with the `CuArray`. This is because the LinearOperator constructor expects `S` to be a `DataType` and therefore doesn't accept `UnionAll`s