### PR TITLE
Dbfgs update

### DIFF
--- a/src/DiagonalHessianApproximation.jl
+++ b/src/DiagonalHessianApproximation.jl
@@ -245,17 +245,16 @@ end
 # y = ∇f(x_{k+1}) - ∇f(x_k)
 function push!(
   B::DiagonalBFGS{T, I, V, F},
-  s0::V,
-  y0::V,
+  s::V,
+  y::V,
 ) where {T <: Real, I <: Integer, V <: AbstractVector{T}, F}
-  s0Norm = norm(s0, 2)
-  if s0Norm == 0
+  sNorm = norm(s, 2)
+  if sNorm == 0
     error("Cannot update DiagonalQN operator with s=0")
   end
-  # sᵀBs = sᵀy can be scaled by ||s||² without changing the update
-  s = (si / s0Norm for si ∈ s0)
-  y = (yi / s0Norm for yi ∈ y0)
-  sT_y = dot(s, y)
-  B.d .= sum(abs.(y)) / sT_y .* abs.(y) 
+  sNorm2 = sNorm^2
+  sT_y = dot(s, y) / sNorm2
+  B.d .= abs.(y)
+  B.d .*= sum(B.d) / sT_y
   return B
 end

--- a/test/test_diag.jl
+++ b/test/test_diag.jl
@@ -120,6 +120,10 @@ end
   mul!(u, C, v)
   @test (@allocated mul!(u, C, v)) == 0
   @test (@wrappedallocs push!(C, u, v)) == 0
+  D = DiagonalBFGS(d)
+  mul!(u, D, v)
+  @test (@allocated mul!(u, D, v)) == 0
+  @test (@wrappedallocs push!(D, u, v)) == 0
 end
 
 @testset "reset" begin


### PR DESCRIPTION
@dpo This PR introduces a new DiagonalBFGS model for the Hessian, as described in Section 7.1 of this paper
https://www.researchgate.net/publication/384428920_A_Proximal_Modified_Quasi-Newton_Method_for_Nonsmooth_Regularized_Optimization