### PR TITLE
fix normest not working on rectangular matrices

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -36,7 +36,7 @@ function normest(S, tol = -1, maxiter = 100)
 
   x ./= e
   e_0 = zero(e)
-  Sx = zeros(eltype(S), n)
+  Sx = zeros(eltype(S), m)
 
   while abs(e - e_0) > tol * e
     e_0 = e

--- a/test/test_normest.jl
+++ b/test/test_normest.jl
@@ -17,8 +17,7 @@ function simple_matrix_test_helper(S, ϵ_norm, ϵ)
 end
 
 function simple_matrix_test(ϵ)
-  (nrow, ncol) = (10, 10)
-  for (nrow, ncol) in [(10, 10), (5, 5), (3, 3)]
+  for (nrow, ncol) in [(10, 10), (5, 5), (3, 3), (3, 5), (5, 3), (5, 10), (10, 5)]
     ϵ_norm = eps(Float64)
     A1 = simple_matrix(ComplexF64, nrow, ncol)
     simple_matrix_test_helper(A1, ϵ_norm, ϵ)


### PR DESCRIPTION
See https://github.com/JuliaSmoothOptimizers/LinearOperators.jl/issues/362