### PR TITLE
Add correct storage_type for lazy wrapped GPU arrays (`adjoint`, `transpose`, `Diagonal`)

### DIFF
--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -174,6 +174,11 @@ storage_type(op::AbstractLinearOperator) = error("please implement storage_type 
 storage_type(op::LinearOperator) = typeof(op.Mv5)
 storage_type(M::AbstractMatrix{T}) where {T} = Vector{T}
 
+# Lazy wrappers
+storage_type(op::Adjoint) = storage_type(parent(op))
+storage_type(op::Transpose) = storage_type(parent(op))
+storage_type(op::Diagonal) = typeof(parent(op))
+
 """
   reset!(op)
 

--- a/test/gpu/amdgpu.jl
+++ b/test/gpu/amdgpu.jl
@@ -16,6 +16,5 @@ using LinearOperators, AMDGPU
   @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
   @test LinearOperators.storage_type(Diagonal(v)) == typeof(v)
 
-
   @testset "AMDGPU S kwarg" test_S_kwarg(arrayType = ROCArray)
 end

--- a/test/gpu/amdgpu.jl
+++ b/test/gpu/amdgpu.jl
@@ -6,10 +6,18 @@ using LinearOperators, AMDGPU
   B = ROCArray(rand(Float32, 10, 10))
   C = ROCArray(rand(Float32, 20, 20))
   M = BlockDiagonalOperator(A, B, C)
+  v = ROCArray(rand(5))
+
 
   v = ROCArray(rand(Float32, 35))
   y = M * v
   @test y isa ROCArray{Float32}
+
+  @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
+  @test LinearOperators.storage_type(A) == LinearOperators.storage_type(transpose(A))
+  @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
+  @test LinearOperators.storage_type(Diagonal(v)) == typeof(v)
+
 
   @testset "AMDGPU S kwarg" test_S_kwarg(arrayType = ROCArray)
 end

--- a/test/gpu/amdgpu.jl
+++ b/test/gpu/amdgpu.jl
@@ -6,8 +6,6 @@ using LinearOperators, AMDGPU
   B = ROCArray(rand(Float32, 10, 10))
   C = ROCArray(rand(Float32, 20, 20))
   M = BlockDiagonalOperator(A, B, C)
-  v = ROCArray(rand(5))
-
 
   v = ROCArray(rand(Float32, 35))
   y = M * v

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -8,7 +8,7 @@ using LinearOperators, CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
   A = CUDA.rand(5, 5)
   B = CUDA.rand(10, 10)
   C = CUDA.rand(20, 20)
-  M = BlockDiagonalOperator(A, B, C)  
+  M = BlockDiagonalOperator(A, B, C)
 
   v = CUDA.rand(35)
   y = M * v

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -19,6 +19,5 @@ using LinearOperators, CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
   @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
   @test LinearOperators.storage_type(Diagonal(v)) == typeof(v)
 
-
   @testset "Nvidia S kwarg" test_S_kwarg(arrayType = CuArray)
 end

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -9,6 +9,13 @@ using LinearOperators, CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
   B = CUDA.rand(10, 10)
   C = CUDA.rand(20, 20)
   M = BlockDiagonalOperator(A, B, C)
+  v = CUDA.rand(5)
+
+  @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
+  @test LinearOperators.storage_type(A) == LinearOperators.storage_type(transpose(A))
+  @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
+  @test LinearOperators.storage_type(Diagonal(v)) == typeof(v)
+  
 
   v = CUDA.rand(35)
   y = M * v

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -8,17 +8,17 @@ using LinearOperators, CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
   A = CUDA.rand(5, 5)
   B = CUDA.rand(10, 10)
   C = CUDA.rand(20, 20)
-  M = BlockDiagonalOperator(A, B, C)
-  v = CUDA.rand(5)
+  M = BlockDiagonalOperator(A, B, C)  
+
+  v = CUDA.rand(35)
+  y = M * v
+  @test y isa CuVector{Float32}
 
   @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
   @test LinearOperators.storage_type(A) == LinearOperators.storage_type(transpose(A))
   @test LinearOperators.storage_type(A) == LinearOperators.storage_type(adjoint(A))
   @test LinearOperators.storage_type(Diagonal(v)) == typeof(v)
-  
 
-  v = CUDA.rand(35)
-  y = M * v
-  @test y isa CuVector{Float32}
+
   @testset "Nvidia S kwarg" test_S_kwarg(arrayType = CuArray)
 end


### PR DESCRIPTION
I noticed that storage_types aren't correctly determined for lazily wrapped GPU arrays. In this PR I dispatch the storage_type based on the parent of the wrapper