### PR TITLE
breakage workflow: update permissions

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -1,6 +1,11 @@
 # Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests
 name: Breakage
 
+# allow breakage/upload when a PR comes from a fork
+permissions:
+  contents: write
+  pull-requests: write
+
 # read-only repo token
 # no access to secrets
 on:


### PR DESCRIPTION
The final step of the breakage workflow (breakage/upload) fails when a pull request comes from a fork because GITHUB_TOKEN restricts permissions in that scenario. This PR always allows breakage/upload to run.