### PR TITLE
Skip `conj.(v)` for real-valued vectors

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -234,6 +234,18 @@ function mul!(
 end
 
 function mul!(
+  res::AbstractVector,
+  op::ConjugateLinearOperator{T, S},
+  v::AbstractVector{<:Real},
+  α,
+  β,
+) where {T, S}
+  p = op.parent
+  mul!(res, p, v, α, β)   # this gets called for A'*v when v is real, so we can skip the conjugation
+  conj!(res)
+end
+
+function mul!(
   res::AbstractMatrix,
   op::ConjugateLinearOperator{T, S},
   v::AbstractMatrix,

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -126,11 +126,12 @@ function mul!(
     increase_nprod!(p)
   end
   conj!(res)
+  vc = eltype(v) <: Real ? v : conj.(v)  # avoid unnecessary allocations if v has real elements
   if hasmethod(tprod!, Tuple{typeof(res), typeof(v), typeof(α), typeof(β)})
-    tprod!(res, conj.(v), conj(α), conj(β))
+    tprod!(res, vc, conj(α), conj(β))
   else
     iszero(β) || !isempty(p.Mtu) || allocate_vectors_args3!(p)
-    prod3!(res, tprod!, conj.(v), conj(α), conj(β), p.Mtu)
+    prod3!(res, tprod!, vc, conj(α), conj(β), p.Mtu)
   end
   conj!(res)
 end
@@ -193,11 +194,12 @@ function mul!(
     increase_nprod!(p)
   end
   conj!(res)
+  vc = eltype(v) <: Real ? v : conj.(v)  # avoid unnecessary allocations when v has real elements
   if hasmethod(ctprod!, Tuple{typeof(res), typeof(v), typeof(α), typeof(β)})
-    ctprod!(res, conj.(v), conj(α), conj(β))
+    ctprod!(res, vc, conj(α), conj(β))
   else
     iszero(β) || !isempty(p.Mtu) || allocate_vectors_args3!(p)
-    prod3!(res, ctprod!, conj.(v), conj(α), conj(β), p.Mtu)
+    prod3!(res, ctprod!, vc, conj(α), conj(β), p.Mtu)
   end
   conj!(res)
 end
@@ -229,7 +231,8 @@ function mul!(
   β,
 ) where {T, S}
   p = op.parent
-  mul!(res, p, conj.(v), α, β)
+  vc = eltype(v) <: Real ? v : conj.(v)  # avoid unnecessary allocations if v has real elements
+  mul!(res, p, vc, α, β)
   conj!(res)
 end
 
@@ -241,7 +244,7 @@ function mul!(
   β,
 ) where {T, S}
   p = op.parent
-  mul!(res, p, v, α, β)   # this gets called for A'*v when v is real, so we can skip the conjugation
+  mul!(res, p, v, α, β)   # we can skip `conj.(v)` since it has real elements (this avoids unnecessary allocations)
   conj!(res)
 end
 

--- a/test/test_adjtrans.jl
+++ b/test/test_adjtrans.jl
@@ -27,8 +27,13 @@ function test_adjtrans()
     v = rand(5) + im * rand(5)
     @test aopA * v == adjoint(A) * v
     @test topA * v == transpose(A) * v
+    v = rand(5)
+    @test aopA * v == adjoint(A) * v
+    @test topA * v == transpose(A) * v
 
     v = rand(3) + im * rand(3)
+    @test copA * v == conj(A) * v
+    v = rand(3)
     @test copA * v == conj(A) * v
   end
 end
@@ -74,8 +79,14 @@ function test_derived_adjoint()
     v = rand(5) + im * rand(5)
     @test aopA * v == adjoint(A) * v
     @test topA * v == transpose(A) * v
+    v = rand(5)
+    @test aopA * v == adjoint(A) * v
+    @test topA * v == transpose(A) * v
+
 
     v = rand(3) + im * rand(3)
+    @test copA * v == conj(A) * v
+    v = rand(3)
     @test copA * v == conj(A) * v
   end
 end
@@ -121,8 +132,14 @@ function test_derived_transpose()
     v = rand(5) + im * rand(5)
     @test aopA * v == adjoint(A) * v
     @test topA * v == transpose(A) * v
+    v = rand(5)
+    @test aopA * v == adjoint(A) * v
+    @test topA * v == transpose(A) * v
+
 
     v = rand(3) + im * rand(3)
+    @test copA * v == conj(A) * v
+    v = rand(3)
     @test copA * v == conj(A) * v
   end
 end

--- a/test/test_adjtrans.jl
+++ b/test/test_adjtrans.jl
@@ -28,13 +28,13 @@ function test_adjtrans()
     @test aopA * v == adjoint(A) * v
     @test topA * v == transpose(A) * v
     v = rand(5)
-    @test aopA * v == adjoint(A) * v
-    @test topA * v == transpose(A) * v
+    @test aopA * v ≈ adjoint(A) * v
+    @test topA * v ≈ transpose(A) * v
 
     v = rand(3) + im * rand(3)
-    @test copA * v == conj(A) * v
+    @test copA * v ≈ conj(A) * v
     v = rand(3)
-    @test copA * v == conj(A) * v
+    @test copA * v ≈ conj(A) * v
   end
 end
 
@@ -80,14 +80,14 @@ function test_derived_adjoint()
     @test aopA * v == adjoint(A) * v
     @test topA * v == transpose(A) * v
     v = rand(5)
-    @test aopA * v == adjoint(A) * v
-    @test topA * v == transpose(A) * v
+    @test aopA * v ≈ adjoint(A) * v
+    @test topA * v ≈ transpose(A) * v
 
 
     v = rand(3) + im * rand(3)
-    @test copA * v == conj(A) * v
+    @test copA * v ≈ conj(A) * v
     v = rand(3)
-    @test copA * v == conj(A) * v
+    @test copA * v ≈ conj(A) * v
   end
 end
 
@@ -133,14 +133,14 @@ function test_derived_transpose()
     @test aopA * v == adjoint(A) * v
     @test topA * v == transpose(A) * v
     v = rand(5)
-    @test aopA * v == adjoint(A) * v
-    @test topA * v == transpose(A) * v
+    @test aopA * v ≈ adjoint(A) * v
+    @test topA * v ≈ transpose(A) * v
 
 
     v = rand(3) + im * rand(3)
-    @test copA * v == conj(A) * v
+    @test copA * v ≈ conj(A) * v
     v = rand(3)
-    @test copA * v == conj(A) * v
+    @test copA * v ≈ conj(A) * v
   end
 end
 


### PR DESCRIPTION
This avoids making an unnecessary copy