### PR TITLE
Use correct syntax for cuSPARSE to avoid warning with CUDA.jl 6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ LinearOperatorsOpNormExt = ["Arpack", "TSVD", "GenericLinearAlgebra"]
 [compat]
 AMDGPU = "2.2.0"
 Arpack = "0.5.4"
-CUDA = "5.9.6, 6"
+CUDA = "6"
 ChainRulesCore = "1"
 FastClosures = "0.3"
 GenericLinearAlgebra = "0.3.19, 0.4"

--- a/ext/LinearOperatorsCUDAExt.jl
+++ b/ext/LinearOperatorsCUDAExt.jl
@@ -1,8 +1,8 @@
 module LinearOperatorsCUDAExt
 
 using LinearOperators
-isdefined(Base, :get_extension) ? (using CUDA; using CUDA.CUSPARSE) :
-(using ..CUDA; using ..CUDA.CUSPARSE)
+isdefined(Base, :get_extension) ? (using CUDA; using CUDA.cuSPARSE) :
+(using ..CUDA; using ..CUDA.cuSPARSE)
 
 LinearOperators.storage_type(::CuArray{T, 2, D}) where {T, D} = CuArray{T, 1, D}
 LinearOperators.storage_type(::AbstractCuSparseMatrix{T}) where {T} =


### PR DESCRIPTION
Drop support for CUDA.jl 5.*